### PR TITLE
新增 notifyWithResult 方法

### DIFF
--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -743,7 +743,7 @@ class Apple extends APayment
     }
 
     /**
-     * @return bool
+     * @return mixed
      */
     public function notifyWithResult()
     {

--- a/src/Provider/Huawei.php
+++ b/src/Provider/Huawei.php
@@ -377,7 +377,7 @@ class Huawei extends APayment
     }
 
     /**
-     * @return bool
+     * @return mixed
      */
     public function notifyWithResult()
     {


### PR DESCRIPTION
原来的 notify 会自动捕获所有错误并响应 500 后终止程序，导致外层无法得知发生了什么。
新增了 notifyWithResult  新方法不会自动响应，会把异常往外抛出，便于外层调用处记录和处理，同时要求调用者自行处理响应。
目前 notify 的方式任然不变。