### PR TITLE
弃用 openssl_free_key 以支持 PHP 8.4

### DIFF
--- a/src/Middleware/JwtAuthorizationMiddleware.php
+++ b/src/Middleware/JwtAuthorizationMiddleware.php
@@ -141,6 +141,9 @@ class JwtAuthorizationMiddleware
         if ($resource === false) {
             throw new \InvalidArgumentException('Private key certificate error');
         }
-        openssl_free_key($resource);
+
+        if (version_compare(PHP_VERSION, '8.0.0', '<')) {
+            openssl_free_key($resource);
+        }
     }
 }

--- a/src/Middleware/JwtAuthorizationMiddleware.php
+++ b/src/Middleware/JwtAuthorizationMiddleware.php
@@ -142,7 +142,7 @@ class JwtAuthorizationMiddleware
             throw new \InvalidArgumentException('Private key certificate error');
         }
 
-        if (version_compare(PHP_VERSION, '8.0.0', '<')) {
+        if (version_compare(PHP_VERSION, '8.0.0', '<') && function_exists('openssl_free_key')) {
             openssl_free_key($resource);
         }
     }


### PR DESCRIPTION
openssl_free_key 在 PHP 8.0 起已被弃用，PHP 8.4 被完全移除，新版本中可以不调用这个方法，目前在 8.4 中会产生错误：

```bash
Function openssl_free_key() is deprecated since 8.0, as OpenSSLAsymmetricKey objects are freed automatically
```